### PR TITLE
Feature/refactor and trade cycling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,13 +4,8 @@
 # against bad commits.
 
 name: build
-on:
-  push:
-    branches:
-      - '**'
-  pull_request:
-    branches:
-      - '**'
+on: [pull_request, push]
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         run: ./gradlew build
       - name: capture build artifacts
         if: ${{ runner.os == 'Linux' && matrix.java == '17' }} # Only upload artifacts built from latest java on one OS
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Artifacts
           path: build/libs/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         run: ./gradlew build
       - name: capture build artifacts
         if: ${{ runner.os == 'Linux' && matrix.java == '17' }} # Only upload artifacts built from latest java on one OS
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Artifacts
           path: build/libs/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,13 @@
 # against bad commits.
 
 name: build
-on: [pull_request, push]
-
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
 jobs:
   build:
     strategy:

--- a/README.md
+++ b/README.md
@@ -14,3 +14,5 @@ disableVillages: prevents village structures from spawning in the world
 curedZombieLoot: if this option is set to null, curing zombie villagers is impossible.
 By supplying lootTable data (for example generated on https://misode.github.io/loot-table/ ), zombie villagers die when they are completely healed and drop the configured loot.
 
+tradeCycling: if this option is set to true, villagers trade will be set in stone when the villagers are spawned.
+

--- a/src/main/java/com/stratecide/disable/villagers/DisableVillagersMod.java
+++ b/src/main/java/com/stratecide/disable/villagers/DisableVillagersMod.java
@@ -10,107 +10,107 @@ import net.minecraft.loot.LootTable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileWriter;
 import java.io.IOException;
-import java.util.Scanner;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 public class DisableVillagersMod implements ModInitializer {
 
 	public static final Logger LOGGER = LoggerFactory.getLogger("disable.villagers");
 	private static final String CONFIG_FOLDER = "config/";
 	private static final String CONFIG_FILE = CONFIG_FOLDER + "disable-villagers.json";
-	private static final String DEFAULT_CONFIG = """
-{
-  "killVillagers": true,
-  "disableWanderingTrader": true,
-  "blockTrading": true,
-  "spareExperiencedVillagers": true,
-  "breeding": false,
-  "disableVillages": true,
-  "disableZombies": false,
-  "curableZombies": true,
-  "curedZombieLoot": {
-	"pools": [
-	  {
-		"rolls": 1,
-		"entries": [
-		  {
-			"type": "minecraft:item",
-			"name": "minecraft:emerald_block"
-		  }
-		]
-	  }
-	]
-  }
-}""";
+	private static final String DEFAULT_CONFIG_PATH = "data/disable-villagers/default_config.json";
 	private static final Gson GSON = LootGsons.getTableGsonBuilder().create();
-	private static boolean isInitialized = false;
-
-	public static boolean killVillagers = false;
-	public static boolean disableWanderingTrader = false;
-	public static boolean blockTrading = false;
-	public static boolean spareExperiencedVillagers = false;
-	public static boolean breeding = false;
-	private static boolean disableZombies = true;
-	public static boolean getDisabledZombies() {
-		loadConfig();
-		return disableZombies;
-	}
-	public static boolean curableZombies = true;
-	private static JsonElement curedZombieLootJson = null;
-	public static LootTable curedZombieLoot = null;
-	private static boolean disableVillages = false;
-	public static boolean getDisabledVillages() {
-		loadConfig();
-		return disableVillages;
-	}
+	
+	private static ModConfig config;
 
 	@Override
 	public void onInitialize() {
 		loadConfig();
-		if (curedZombieLootJson != null)
-			curedZombieLoot = GSON.fromJson(curedZombieLootJson, LootTable.class);
+		LOGGER.info("DisableVillagers mod initialized with configuration: {}", config);
 	}
 
+	/**
+	 * Loads the mod configuration from file or creates default if not present
+	 */
 	private static void loadConfig() {
-		if (isInitialized)
-			return;
-		isInitialized = true;
-		File file = new File(CONFIG_FILE);
-		String data;
-		if (!file.exists()) {
-			file.getParentFile().mkdirs();
-			data = DEFAULT_CONFIG;
-			try (FileWriter writer = new FileWriter(CONFIG_FILE)) {
-				writer.write(data);
+		try {
+			Path configPath = Path.of(CONFIG_FILE);
+			String configData;
+
+			if (!Files.exists(configPath)) {
+				LOGGER.info("Creating default configuration file");
+				Files.createDirectories(configPath.getParent());
+				configData = loadDefaultConfig();
+				Files.writeString(configPath, configData);
+			} else {
+				configData = Files.readString(configPath);
 			}
-			catch (IOException e) {
-				e.printStackTrace();
+
+			JsonObject jsonConfig = JsonParser.parseString(configData).getAsJsonObject();
+			config = new ModConfig(jsonConfig);
+			LOGGER.info("Configuration loaded successfully");
+		} catch (IOException e) {
+			LOGGER.error("Failed to load configuration", e);
+			// Fallback to default config
+			try {
+				String defaultConfig = loadDefaultConfig();
+				config = new ModConfig(JsonParser.parseString(defaultConfig).getAsJsonObject());
+			} catch (IOException ex) {
+				LOGGER.error("Failed to load default configuration", ex);
+				throw new RuntimeException("Failed to load configuration", ex);
 			}
 		}
-		else {
-			try (Scanner scanner = new Scanner(file)) {
-				StringBuilder builder = new StringBuilder();
-				while (scanner.hasNextLine())
-					builder.append(scanner.nextLine());
-				data = builder.toString();
+	}
+
+	private static String loadDefaultConfig() throws IOException {
+		try (InputStream is = DisableVillagersMod.class.getClassLoader().getResourceAsStream(DEFAULT_CONFIG_PATH)) {
+			if (is == null) {
+				throw new IOException("Default configuration file not found in resources");
 			}
-			catch (FileNotFoundException e) {
-				e.printStackTrace();
-				data = DEFAULT_CONFIG;
-			}
+			return new String(is.readAllBytes());
 		}
-		JsonObject config = JsonParser.parseString(data).getAsJsonObject();
-		killVillagers = config.get("killVillagers").getAsBoolean();
-		disableWanderingTrader = config.has("disableWanderingTrader") && config.get("disableWanderingTrader").getAsBoolean();
-		blockTrading = config.get("blockTrading").getAsBoolean();
-		spareExperiencedVillagers = config.get("spareExperiencedVillagers").getAsBoolean();
-		breeding = config.get("breeding").getAsBoolean();
-		disableZombies = config.has("disableZombies") && config.get("disableZombies").getAsBoolean();
-		curableZombies = config.get("curableZombies").getAsBoolean();
-		disableVillages = config.get("disableVillages").getAsBoolean();
-		curedZombieLootJson = config.get("curedZombieLoot");
+	}
+
+	// Configuration getters
+	public static boolean isKillVillagers() {
+		return config.killVillagers;
+	}
+
+	public static boolean isDisableWanderingTrader() {
+		return config.disableWanderingTrader;
+	}
+
+	public static boolean isBlockTrading() {
+		return config.blockTrading;
+	}
+
+	public static boolean isSpareExperiencedVillagers() {
+		return config.spareExperiencedVillagers;
+	}
+
+	public static boolean isBreeding() {
+		return config.breeding;
+	}
+
+	public static boolean isDisableZombies() {
+		return config.disableZombies;
+	}
+
+	public static boolean isCurableZombies() {
+		return config.curableZombies;
+	}
+
+	public static boolean isDisableVillages() {
+		return config.disableVillages;
+	}
+
+	public static LootTable getCuredZombieLoot() {
+		return config.curedZombieLoot;
+	}
+
+	public static boolean isTradeCycling() {
+		return config.tradeCycling;
 	}
 }

--- a/src/main/java/com/stratecide/disable/villagers/ModConfig.java
+++ b/src/main/java/com/stratecide/disable/villagers/ModConfig.java
@@ -21,6 +21,7 @@ public class ModConfig {
     public final boolean curableZombies;
     public final boolean disableVillages;
     public final LootTable curedZombieLoot;
+    public final boolean tradeCycling;
 
     public ModConfig(JsonObject json) {
         this.killVillagers = json.get("killVillagers").getAsBoolean();

--- a/src/main/java/com/stratecide/disable/villagers/ModConfig.java
+++ b/src/main/java/com/stratecide/disable/villagers/ModConfig.java
@@ -1,0 +1,39 @@
+package com.stratecide.disable.villagers;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import net.minecraft.loot.LootGsons;
+import net.minecraft.loot.LootTable;
+
+/**
+ * Configuration class to hold all mod settings
+ */
+public class ModConfig {
+    private static final Gson GSON = LootGsons.getTableGsonBuilder().create();
+
+    public final boolean killVillagers;
+    public final boolean disableWanderingTrader;
+    public final boolean blockTrading;
+    public final boolean spareExperiencedVillagers;
+    public final boolean breeding;
+    public final boolean disableZombies;
+    public final boolean curableZombies;
+    public final boolean disableVillages;
+    public final LootTable curedZombieLoot;
+
+    public ModConfig(JsonObject json) {
+        this.killVillagers = json.get("killVillagers").getAsBoolean();
+        this.disableWanderingTrader = json.has("disableWanderingTrader") && json.get("disableWanderingTrader").getAsBoolean();
+        this.blockTrading = json.get("blockTrading").getAsBoolean();
+        this.spareExperiencedVillagers = json.get("spareExperiencedVillagers").getAsBoolean();
+        this.breeding = json.get("breeding").getAsBoolean();
+        this.disableZombies = json.has("disableZombies") && json.get("disableZombies").getAsBoolean();
+        this.curableZombies = json.get("curableZombies").getAsBoolean();
+        this.disableVillages = json.get("disableVillages").getAsBoolean();
+        this.tradeCycling = json.get("tradeCycling").getAsBoolean();
+
+        JsonElement lootJson = json.get("curedZombieLoot");
+        this.curedZombieLoot = lootJson != null ? GSON.fromJson(lootJson, LootTable.class) : null;
+    }
+} 

--- a/src/main/java/com/stratecide/disable/villagers/mixin/DefaultBiomeFeaturesMixin.java
+++ b/src/main/java/com/stratecide/disable/villagers/mixin/DefaultBiomeFeaturesMixin.java
@@ -16,8 +16,9 @@ public class DefaultBiomeFeaturesMixin {
      */
     @ModifyVariable(method = "addMonsters", at = @At("HEAD"), ordinal = 0)
     private static int fixZombieChance(int weight, SpawnSettings.Builder builder, int zombieWeight, int zombieVillagerWeight, int skeletonWeight) {
-        if (DisableVillagersMod.getDisabledZombies())
+        if (DisableVillagersMod.isDisableZombies()) {
             return weight + zombieVillagerWeight;
+        }
         return weight;
     }
 
@@ -26,8 +27,9 @@ public class DefaultBiomeFeaturesMixin {
      */
     @Redirect(method = "addMonsters", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/biome/SpawnSettings$Builder;spawn(Lnet/minecraft/entity/SpawnGroup;Lnet/minecraft/world/biome/SpawnSettings$SpawnEntry;)Lnet/minecraft/world/biome/SpawnSettings$Builder;", ordinal = 2))
     private static SpawnSettings.Builder removeZombieVillagers(SpawnSettings.Builder builder, SpawnGroup spawnGroup, SpawnSettings.SpawnEntry spawnEntry) {
-        if (!DisableVillagersMod.getDisabledZombies())
+        if (!DisableVillagersMod.isDisableZombies()) {
             return builder.spawn(spawnGroup, spawnEntry);
+        }
         return builder;
     }
 }

--- a/src/main/java/com/stratecide/disable/villagers/mixin/MerchantEntityMixin.java
+++ b/src/main/java/com/stratecide/disable/villagers/mixin/MerchantEntityMixin.java
@@ -14,9 +14,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public class MerchantEntityMixin {
 
     @Inject(method = "getOffers", at = @At("HEAD"), cancellable = true)
-    private void injectGetOffers(CallbackInfoReturnable<TradeOfferList> cir) {
-        if (DisableVillagersMod.blockTrading && ((Object) this) instanceof VillagerEntity
-        || DisableVillagersMod.disableWanderingTrader && ((Object) this) instanceof WanderingTraderEntity) {
+    private void onGetOffersInject(CallbackInfoReturnable<TradeOfferList> cir) {
+        Object self = this;
+        if ((self instanceof VillagerEntity && DisableVillagersMod.isBlockTrading()) ||
+            (self instanceof WanderingTraderEntity && DisableVillagersMod.isDisableWanderingTrader())) {
             cir.setReturnValue(new TradeOfferList());
         }
     }

--- a/src/main/java/com/stratecide/disable/villagers/mixin/StructurePlacementCalculatorMixin.java
+++ b/src/main/java/com/stratecide/disable/villagers/mixin/StructurePlacementCalculatorMixin.java
@@ -15,19 +15,17 @@ import java.util.stream.Stream;
 
 @Mixin(StructurePlacementCalculator.class)
 public class StructurePlacementCalculatorMixin {
+
     @ModifyVariable(method = "create(Lnet/minecraft/world/gen/noise/NoiseConfig;JLnet/minecraft/world/biome/source/BiomeSource;Ljava/util/stream/Stream;)Lnet/minecraft/world/gen/chunk/placement/StructurePlacementCalculator;", at = @At("HEAD"), argsOnly = true)
-    private static Stream<RegistryEntry<StructureSet>> removeVillages1(Stream<RegistryEntry<StructureSet>> structureSets) {
-        if (DisableVillagersMod.getDisabledVillages()) {
-            return structureSets.filter(entry ->
-                    !entry.matchesKey(StructureSetKeys.VILLAGES)
-            );
-        } else {
-            return structureSets;
+    private static Stream<RegistryEntry<StructureSet>> filterVillageStructures(Stream<RegistryEntry<StructureSet>> structureSets) {
+        if (DisableVillagersMod.isDisableVillages()) {
+            return structureSets.filter(entry -> !entry.matchesKey(StructureSetKeys.VILLAGES));
         }
+        return structureSets;
     }
 
     @Redirect(method = "create(Lnet/minecraft/world/gen/noise/NoiseConfig;JLnet/minecraft/world/biome/source/BiomeSource;Lnet/minecraft/registry/RegistryWrapper;)Lnet/minecraft/world/gen/chunk/placement/StructurePlacementCalculator;", at = @At(value = "INVOKE", target = "Ljava/util/stream/Stream;collect(Ljava/util/stream/Collector;)Ljava/lang/Object;"))
-    private static Object removeVillages2(Stream<RegistryEntry<StructureSet>> stream, Collector collector) {
-        return removeVillages1(stream).collect(collector);
+    private static Object filterAndCollectStructures(Stream<RegistryEntry<StructureSet>> stream, Collector collector) {
+        return filterVillageStructures(stream).collect(collector);
     }
 }

--- a/src/main/java/com/stratecide/disable/villagers/mixin/VillagerMixin.java
+++ b/src/main/java/com/stratecide/disable/villagers/mixin/VillagerMixin.java
@@ -4,6 +4,10 @@ import com.stratecide.disable.villagers.DisableVillagersMod;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityInteraction;
 import net.minecraft.entity.EntityType;
+import net.minecraft.village.VillagerData;
+import net.minecraft.village.VillagerType;
+import net.minecraft.village.VillagerProfession;
+import net.minecraft.entity.ai.brain.MemoryModuleType;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.passive.MerchantEntity;
 import net.minecraft.entity.passive.VillagerEntity;
@@ -43,8 +47,24 @@ public abstract class VillagerMixin extends MerchantEntity {
         }
     }
     
-    // TODO: Trade cycling
-
+    @Inject(method = "fillRecipes", at = @At("RETURN"))
+    private void onFillRecipesInject(CallbackInfo ci) {
+        if (!DisableVillagersMod.isTradeCycling()) {
+            VillagerEntity villager = (VillagerEntity) (Object) this;
+    
+            // Lock current profession and level
+            VillagerData data = villager.getVillagerData();
+            villager.setVillagerData(new VillagerData(
+                data.getType(),
+                data.getProfession(),
+                data.getLevel()
+            ));
+    
+            // Prevent further changes by removing job site memory
+            villager.getBrain().forget(MemoryModuleType.JOB_SITE);
+        }
+    }
+    
     @Inject(method = "onInteractionWith", at=@At("HEAD"), cancellable = true)
     private void onInteractionWithInject(EntityInteraction interaction, Entity player, CallbackInfo ci) {
         if (DisableVillagersMod.getCuredZombieLoot() == null || interaction != EntityInteraction.ZOMBIE_VILLAGER_CURED) {

--- a/src/main/java/com/stratecide/disable/villagers/mixin/WanderingTraderManagerMixin.java
+++ b/src/main/java/com/stratecide/disable/villagers/mixin/WanderingTraderManagerMixin.java
@@ -10,9 +10,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(WanderingTraderManager.class)
 public class WanderingTraderManagerMixin {
+
     @Inject(method = "spawn", at = @At("HEAD"), cancellable = true)
-    void blockWanderingTraders(ServerWorld world, boolean spawnMonsters, boolean spawnAnimals, CallbackInfoReturnable<Integer> cir) {
-        if (DisableVillagersMod.disableWanderingTrader) {
+    private void onSpawnBlockWanderingTraders(ServerWorld world, boolean spawnMonsters,boolean spawnAnimals, CallbackInfoReturnable<Integer> cir) {
+        if (DisableVillagersMod.isDisableWanderingTrader()) {
             cir.setReturnValue(0);
         }
     }

--- a/src/main/java/com/stratecide/disable/villagers/mixin/ZombieVillagerMixin.java
+++ b/src/main/java/com/stratecide/disable/villagers/mixin/ZombieVillagerMixin.java
@@ -28,15 +28,15 @@ public abstract class ZombieVillagerMixin extends ZombieEntity {
 
 	@Shadow private UUID converter;
 
-	public ZombieVillagerMixin(World world) {
+	protected ZombieVillagerMixin(World world) {
 		super(world);
 	}
 
 	@Inject(method = "interactMob", at=@At("HEAD"), cancellable = true)
-	private void interactMobInject(PlayerEntity player, Hand hand, CallbackInfoReturnable<ActionResult> cir) {
-		if (!DisableVillagersMod.curableZombies) {
+	private void onInteractMobInject(PlayerEntity player, Hand hand, CallbackInfoReturnable<ActionResult> cir) {
+		if (!DisableVillagersMod.isCurableZombies()) {
 			ItemStack itemStack = player.getStackInHand(hand);
-			if (itemStack.getItem() == Items.GOLDEN_APPLE) {
+			if (itemStack == Items.GOLDEN_APPLE) {
 				cir.setReturnValue(ActionResult.PASS);
 			}
 		}

--- a/src/main/java/com/stratecide/disable/villagers/mixin/ZombieVillagerMixin.java
+++ b/src/main/java/com/stratecide/disable/villagers/mixin/ZombieVillagerMixin.java
@@ -36,7 +36,7 @@ public abstract class ZombieVillagerMixin extends ZombieEntity {
 	private void onInteractMobInject(PlayerEntity player, Hand hand, CallbackInfoReturnable<ActionResult> cir) {
 		if (!DisableVillagersMod.isCurableZombies()) {
 			ItemStack itemStack = player.getStackInHand(hand);
-			if (itemStack == Items.GOLDEN_APPLE) {
+			if (itemStack.isOf(Items.GOLDEN_APPLE)) {
 				cir.setReturnValue(ActionResult.PASS);
 			}
 		}

--- a/src/main/resources/data/disable-villagers/default_config.json
+++ b/src/main/resources/data/disable-villagers/default_config.json
@@ -1,0 +1,24 @@
+{
+  "killVillagers": true,
+  "disableWanderingTrader": true,
+  "blockTrading": true,
+  "spareExperiencedVillagers": true,
+  "breeding": false,
+  "disableVillages": true,
+  "disableZombies": false,
+  "curableZombies": true,
+  "tradeCycling": true,
+  "curedZombieLoot": {
+    "pools": [
+      {
+        "rolls": 1,
+        "entries": [
+          {
+            "type": "minecraft:item",
+            "name": "minecraft:emerald_block"
+          }
+        ]
+      }
+    ]
+  }
+} 


### PR DESCRIPTION
- Refactor main `DisableVillagersMod` class and some small tweaks

- Added tradeCycling setting:
When set to false, players can no longer reset trades by breaking and replacing job site blocks.

Combined with existing options (like disabling breeding), this can nerf villager and makes each individual villager more valuable.